### PR TITLE
Adjusted naming to conform with api changes

### DIFF
--- a/ios/MetronomeModule.swift
+++ b/ios/MetronomeModule.swift
@@ -41,7 +41,7 @@ class MetronomeModule: NSObject, RCTInvalidating {
     guard let url = Bundle.main.url(forResource: "metronome", withExtension: "wav") else { print("metronome.wav file not found"); return; };
 
     do {
-      try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayback, mode: AVAudioSessionModeDefault);
+      try AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.playback, mode: AVAudioSession.Mode.default);
       try AVAudioSession.sharedInstance().setActive(true);
 
       self.player = try AVAudioPlayer(contentsOf: url, fileTypeHint: AVFileType.wav.rawValue);


### PR DESCRIPTION
Fixes [error](https://github.com/jonestristand/react-native-metronome-module/issues/3#issuecomment-1326342263)  encountered in issue #3 due to AVAudioSession api changes