### PR TITLE
Fixed main queue setup Warning

### DIFF
--- a/ios/MetronomeModule.m
+++ b/ios/MetronomeModule.m
@@ -15,4 +15,9 @@ RCT_EXTERN_METHOD(getShouldPauseOnLostFocus:(RCTPromiseResolveBlock)resolve reje
 RCT_EXTERN_METHOD(isPlaying:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(isPaused:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
+
 @end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-metronome-module",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Cross-platform metronome module for iOS and Android",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
react-native version used: ```0.70.6```

Warning appearing on app init ```Module MetronomeModule requires main queue setup since it overrides 'init' but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of```

PR fixes this warning with the assumption MainQueueSetup is not needed.